### PR TITLE
fix: add eslint:recommended

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,7 @@
 module.exports = {
   root: true,
-  extends: '@react-native',
+  extends: [
+    '@react-native',
+    'eslint:recommended',
+  ],
 };


### PR DESCRIPTION
Without this, eslint was not warning me about an undefined variable reference. I imagine there are some other good rules in here, too.