### PR TITLE
chore: remove duplicate formatDuration function

### DIFF
--- a/components/ArchivedShowView.tsx
+++ b/components/ArchivedShowView.tsx
@@ -29,7 +29,7 @@ import { PlaylistResponse, PlaylistSong } from '../types/Playlist';
 import { PlaylistService } from '../services/PlaylistService';
 import { ArchiveService } from '../services/ArchiveService';
 import { getWMBRLogoSVG } from '../utils/WMBRLogo';
-import { formatDate, formatDuration, formatTime } from '../utils/DateTime';
+import { formatDate, secondsToTime, formatTime } from '../utils/DateTime';
 import { generateDarkGradientColors, generateGradientColors } from '../utils/GradientColors';
 
 const { width, height } = Dimensions.get('window');
@@ -308,9 +308,9 @@ export default function ArchivedShowView({ show, archive, isVisible, onClose }: 
                   </GestureDetector>
                   <View style={styles.timeContainer}>
                     <Text style={styles.timeText}>
-                      {formatDuration(isDragging ? scrubPosition : progress.position)}
+                      {secondsToTime(isDragging ? scrubPosition : progress.position)}
                     </Text>
-                    <Text style={styles.timeText}>{formatDuration(progress.duration)}</Text>
+                    <Text style={styles.timeText}>{secondsToTime(progress.duration)}</Text>
                   </View>
                 </View>
               </View>

--- a/utils/DateTime.ts
+++ b/utils/DateTime.ts
@@ -1,11 +1,5 @@
 import { Show } from '../types/RecentlyPlayed';
 
-export const formatDuration = (seconds: number) => {
-  const minutes = Math.floor(seconds / 60);
-  const remainingSeconds = Math.floor(seconds % 60);
-  return `${minutes}:${remainingSeconds.toString().padStart(2, '0')}`;
-};
-
 export const formatDate = (dateString: string) => {
   const date = new Date(dateString);
   return date.toLocaleDateString('en-US', {


### PR DESCRIPTION
This will change the "Total Time" indicator on an archived show play page to something like "1:04:00" instead of "64:00" -- but also just combining these very similar functions into one.

**Before**

<img width="456" height="972" alt="Screenshot 2025-11-08 at 10 02 57 AM" src="https://github.com/user-attachments/assets/ebdcbd7d-c53a-4ffa-86cc-fdc1145c3c7d" />

**After**

<img width="456" height="972" alt="Screenshot 2025-11-08 at 10 03 02 AM" src="https://github.com/user-attachments/assets/8a304f4e-fbb5-40d2-9928-937ee86a9f0e" />
