### PR TITLE
chore: gitignore android/local.properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # React Native
 node_modules/
 android/.gradle/
+android/local.properties
 android/app/build/
 android/app/.cxx/
 ios/Pods/


### PR DESCRIPTION
This is created when simulating an Android app locally, but contains details specific to a user's computer, so shouldn't be committed.