### PR TITLE
docs: add agents.md files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,42 @@
+# WMBR Mobile App - Quick Reference
+
+React Native app for WMBR radio streaming (live + archives), schedules, and playlists.
+
+## Project Structure
+
+- **App Shell & Tabs**: `src/app/index.tsx` (Bottom tab navigator + custom bar)
+- **Screens / Feature Modules** (grouped by domain under `src/app/`)
+  - Home: `src/app/Home/*`
+  - Schedule (stack navigator): `src/app/Schedule/index.tsx` (+ `ShowDetailsPage.tsx`, `ArchivedShowView.tsx`)
+  - Recently Played: `src/app/RecentlyPlayed/*`
+  - About: `src/app/About/*`
+  - Custom Tab Bar: `src/app/_BottomMenuBar.tsx`
+- **Services**: `src/services/*.ts` (`ScheduleService`, `RecentlyPlayedService`, `TrackPlayerService`)
+- **Types**: `src/types/*.ts`
+- **Utils**: `src/utils/*.ts` (e.g. `Debug.ts`, date helpers, colors, logo SVG)
+- **Mocks**: `__mocks__/MockNetworkResponses.ts`
+- **Tests**: `__tests__/*.test.tsx`
+
+## Architecture
+
+- **Navigation**: React Navigation bottom tabs (`@react-navigation/bottom-tabs`) with a custom tab bar component (`_BottomMenuBar.tsx`).
+- **Nested Stack**: The Schedule feature exposes a native stack (`ScheduleStack`) declared in `src/app/Schedule/index.tsx` (previously referenced as `SchedulePage.tsx` – filename corrected).
+- **Audio Playback**: `react-native-track-player@^4.1.1` service in `src/services/TrackPlayerService.ts` (remote event listeners only currently).
+- **Data Retrieval**:
+  - Schedule + Archives: XML endpoints parsed via `react-native-xml2js`.
+  - Playlists: JSON endpoint (`alexandersimoes.com/get_playlist`).
+- **State & Caching**: `RecentlyPlayedService` maintains in‑memory caches (songs + shows + season start) with a 5‑minute TTL; `ScheduleService` parses XML fresh per request but can be extended with its own cache later.
+- **Alternating Show Logic**: Both services interpret `alternates` codes:
+  - `0` weekly / weekdays
+  - `1` & `2` alternate every other week (pair at same timeslot)
+  - `5–8` one specific week in a 4‑week cycle (Week 1–4)
+  - Weekday shows use `day=7` and are expanded across Monday–Friday.
+
+## Data Flow (High Level)
+
+```
+UI Screen -> Service Method -> fetch(XML/JSON) -> parse -> transform -> cache -> render
+```
+
+- Schedule screen: `ScheduleService.fetchSchedule()` → group by day → render list → drill into `ShowDetailsPage` (archives fetched through `RecentlyPlayedService.fetchShowsCacheOnly()` when show tapped).
+- Recently Played screen: `RecentlyPlayedService.fetchRecentlyPlayed()` → fetch schedule + archives + each show playlist (today) → group songs by show.

--- a/__tests__/AGENTS.md
+++ b/__tests__/AGENTS.md
@@ -1,0 +1,94 @@
+# Testing Guidelines
+
+## Recommended Test Patterns
+
+```typescript
+import { render, screen, userEvent } from '@testing-library/react-native';
+import { ScheduleStack } from '../src/app/Schedule';
+import { TestWrapper } from '../src/utils/TestUtils';
+// TestWrapper includes SafeAreaProvider and NavigationContainer. Only necessary
+for components that depend on those contextswraps.
+
+test('shows schedule and navigates to details', async () => {
+  const user = userEvent.setup();
+  render(<ScheduleStack />, { wrapper: TestWrapper });
+
+  // Wait for a known show from mock schedule XML
+  expect(await screen.findByText('Africa Kabisa')).toBeTruthy();
+
+  // Navigate into details (archives fetch via RecentlyPlayedService)
+  await user.press(screen.getByText('Africa Kabisa'));
+
+  // Header/title or archive-related content appears
+  expect(await screen.findByText(/Show Details|Archived Show/i)).toBeTruthy();
+});
+```
+
+Render stacks/containers for navigation-dependent components. Example: prefer `render(<ScheduleStack />)` over rendering an inner page that depends on `useNavigation` or header context.
+
+## Async & Query Strategy
+
+- Prefer `await screen.findBy*()` queries for async/network-driven elements; avoid manual `waitFor` for simple appearance checks.
+- Use `userEvent` for interactions rather than `fireEvent`.
+- Query preference: `getByRole` → `getByLabelText` → `getByText` → `getByTestId` (last).
+
+## Mocks
+
+### Mock at boundaries, not internals
+
+- Mock: `fetch`, native modules, console, non-deterministic functions
+
+### Avoid over-mocking
+
+- Do **not** mock: Services (`ScheduleService`, `RecentlyPlayedService`), utilities, constants, pure transforms
+
+**Why:** Preserves refactor resilience, exercises real parsing & transformation paths. Real services run: XML parsing (`react-native-xml2js`), playlist mapping → `ProcessedSong[]`, alternating logic.
+
+### Jest setup & mocks
+
+- `react-native-track-player` (mocked in `jest.setup.ts`)
+- `react-native-gesture-handler` (mocked in `jest.setup.ts`)
+- `src/utils/Debug.ts` silenced in tests
+- Track player mock is minimal (hooks returning promises) — extend per test needs if more states are required.
+
+Add new mocks only if they introduce true external nondeterminism.
+
+### Playlist and schedule mocks
+
+`global.fetch` via `__mocks__/MockNetworkResponses.ts` (network boundary)
+
+```typescript
+// jest.setup.ts
+global.fetch = createMockFetch(); // Provides XML + playlist mocks
+```
+
+To extend playlist mock, add seeded JSON responses in `__mocks__/MockNetworkResponses.ts` and return them from `createMockFetch()` by detecting the show name in the playlist URL (`show_name` or the show string).
+
+Example (inside `__mocks__/MockNetworkResponses.ts`):
+```ts
+const mockPlaylistForNewShow: PlaylistResponse = {
+  show_name: 'New Show',
+  date: '2025-11-01',
+  playlist_id: '99999',
+  songs: [
+    { time: '2025/11/01 21:00:00', artist: 'Artist', song: 'Title', album: 'Album' },
+  ],
+};
+
+// In createMockFetch():
+if (urlStr.includes('alexandersimoes.com/get_playlist')) {
+  if (urlStr.includes('New+Show') || urlStr.includes('New-Show') || urlStr.includes('New Show')) {
+    return Promise.resolve({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(mockPlaylistForNewShow),
+    } as Response);
+  }
+  // existing branches...
+}
+```
+
+---
+Resources:
+- Testing Library: https://testing-library.com/docs/react-native-testing-library/intro/
+- Jest: https://jestjs.io/docs/getting-started


### PR DESCRIPTION
Adding AGENTS.md files for use by LLM assistants, so they don't have to figure everything out about the project on their own.

In my own experience this helps **immensely** with how useful LLM assistants can be, if you choose to use them.