### PR TITLE
docs: add linting to copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,4 @@
 ## Required Before Each Commit
 
-- Run `npx run eslint . --fix` to ensure consistent code formatting with
+- Run `npx eslint . --fix` to ensure consistent code formatting with
     ESLint/Prettier


### PR DESCRIPTION
There's no programmatic way to do this, unfortunately, but this is an attempt to get Copilot to fix the linting on any PRs it may create while ~hallucinating~ developing