### PR TITLE
Add download links for Apple and Google Play stores

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A React Native app for streaming WMBR 88.1 FM and browsing show archives, song history, and schedules.
 
+You can download the latest release from the [Apple](https://apps.apple.com/app/wmbr/id6749026414) and [Google Play](https://apps.apple.com/app/wmbr/id6749026414) mobile app stores.
+
 ## Features
 
 - **Live Stream**: Listen to WMBR 88.1 FM with live show information


### PR DESCRIPTION
Adds quick links to the store pages for the published apps.

I was sharing and noticed that there wasn't an easy way to jump to the newest release. I put it in the top section, since I think there's a good chance non-app-developers will find this via a search and want to use the app - this way they can get to the friendlier pages without being scared off.

Happy to tweak wording!