### PR TITLE
fix: html decode show hosts on home (#147)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "@react-native/metro-config": "0.80.1",
         "@react-native/typescript-config": "0.80.1",
         "@testing-library/react-native": "^13.3.0",
+        "@types/he": "^1.2.3",
         "@types/jest": "^29.5.13",
         "@types/react": "^19.1.0",
         "@types/react-native-vector-icons": "^6.4.18",
@@ -3639,6 +3640,13 @@
       "version": "2.0.46",
       "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.46.tgz",
       "integrity": "sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/he": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@types/he/-/he-1.2.3.tgz",
+      "integrity": "sha512-q67/qwlxblDzEDvzHhVkwc1gzVWxaNxeyHUBF4xElrvjL11O+Ytze+1fGpBHlr/H9myiBUaUXNnNPmBHxxfAcA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-coverage": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@react-navigation/bottom-tabs": "^7.4.9",
         "@react-navigation/native": "^7.1.18",
         "@react-navigation/native-stack": "^7.3.28",
+        "he": "^1.2.0",
         "react": "19.1.0",
         "react-native": "0.80.1",
         "react-native-gesture-handler": "^2.28.0",
@@ -7480,6 +7481,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
       }
     },
     "node_modules/hermes-estree": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@react-navigation/bottom-tabs": "^7.4.9",
     "@react-navigation/native": "^7.1.18",
     "@react-navigation/native-stack": "^7.3.28",
+    "he": "^1.2.0",
     "react": "19.1.0",
     "react-native": "0.80.1",
     "react-native-gesture-handler": "^2.28.0",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@react-native/metro-config": "0.80.1",
     "@react-native/typescript-config": "0.80.1",
     "@testing-library/react-native": "^13.3.0",
+    "@types/he": "^1.2.3",
     "@types/jest": "^29.5.13",
     "@types/react": "^19.1.0",
     "@types/react-native-vector-icons": "^6.4.18",

--- a/src/app/Home/index.tsx
+++ b/src/app/Home/index.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState, useMemo, useCallback } from 'react';
+import he from 'he';
 import { debugError } from '@utils/Debug';
 import {
   View,
@@ -94,7 +95,7 @@ export default function HomeScreen() {
     const unsubscribeMetadata = metadataService.subscribe((data: ShowInfo) => {
       setShowInfo(data);
       setCurrentShow(data.showTitle);
-      setHosts(data.hosts);
+      setHosts(he.decode(data.hosts));
       setShowDescription(data.description);
 
       try {

--- a/src/app/Home/index.tsx
+++ b/src/app/Home/index.tsx
@@ -95,7 +95,7 @@ export default function HomeScreen() {
     const unsubscribeMetadata = metadataService.subscribe((data: ShowInfo) => {
       setShowInfo(data);
       setCurrentShow(data.showTitle);
-      setHosts(he.decode(data.hosts));
+      setHosts(he.decode(data.hosts || ''));
       setShowDescription(data.description);
 
       try {


### PR DESCRIPTION
Fixes #147 

Had to add another dependency, but I didn't see a way around that. Some Google results recommended `<WebView>`, but that's a separate library now.