### PR TITLE
feat: add show description to show detail page (#152)

### DIFF
--- a/__tests__/SchedulePage.test.tsx
+++ b/__tests__/SchedulePage.test.tsx
@@ -27,6 +27,7 @@ describe('SchedulePage', () => {
     expect(screen.getByText('Archives')).toBeTruthy();
     expect(screen.getByText('88.1 FM')).toBeTruthy();
     expect(screen.getByText(/archived episode/)).toBeTruthy();
+    expect(screen.getByText('post music for post people.')).toBeTruthy();
   });
 
   test('navigates to ArchivedShowView when tapping an archive in ShowDetails', async () => {

--- a/src/app/Home/index.tsx
+++ b/src/app/Home/index.tsx
@@ -35,6 +35,7 @@ import { COLORS, CORE_COLORS } from '@utils/Colors';
 import { formatArchiveDate } from '@utils/DateTime';
 
 import HomeNowPlaying from './HomeNowPlaying';
+import { ScheduleService } from '@services/ScheduleService';
 
 const streamUrl = 'https://wmbr.org:8002/hi';
 
@@ -55,6 +56,8 @@ export default function HomeScreen() {
     currentShow: null,
     liveStreamUrl: streamUrl,
   });
+
+  const scheduleService = ScheduleService.getInstance();
 
   const isPlaying = playbackState?.state === State.Playing;
 
@@ -231,9 +234,11 @@ export default function HomeScreen() {
     await TrackPlayer.seekTo(newPosition);
   }, [progress.position, progress.duration]);
 
-  const handleOpenShowDetails = useCallback(() => {
+  const handleOpenShowDetails = useCallback(async () => {
     const show = archiveState.currentShow;
     if (!show) return;
+
+    const scheduleShow = await scheduleService.getShowById(show.id);
 
     // Navigate to Schedule tab with complete stack state
     navigation.navigate('Schedule' as WmbrRouteName, {
@@ -241,7 +246,7 @@ export default function HomeScreen() {
       state: {
         routes: [
           { name: 'ScheduleMain' },
-          { name: 'ShowDetails', params: { show } },
+          { name: 'ShowDetails', params: { show, scheduleShow } },
           {
             name: 'ArchivedShowView',
             params: { show, archive: archiveState.currentArchive },
@@ -249,7 +254,12 @@ export default function HomeScreen() {
         ],
       },
     });
-  }, [archiveState.currentShow, archiveState.currentArchive, navigation]);
+  }, [
+    archiveState.currentShow,
+    archiveState.currentArchive,
+    scheduleService,
+    navigation,
+  ]);
 
   if (showSplash) return <SplashScreen onAnimationEnd={handleSplashEnd} />;
 

--- a/src/app/Schedule/SchedulePage.tsx
+++ b/src/app/Schedule/SchedulePage.tsx
@@ -79,7 +79,7 @@ export default function SchedulePage({ currentShow }: SchedulePageProps) {
     }
   }, [scheduleService]);
 
-  const handleShowPress = async (show: ScheduleShow) => {
+  const handleShowPress = async (scheduleShow: ScheduleShow) => {
     try {
       // Fetch archives for this show from the recently played service
       const recentlyPlayedService = RecentlyPlayedService.getInstance();
@@ -88,22 +88,18 @@ export default function SchedulePage({ currentShow }: SchedulePageProps) {
       await recentlyPlayedService.fetchShowsCacheOnly();
 
       // find the show from the cache
-      const showWithArchiveData = recentlyPlayedService.getShowByName(
-        show.name,
-      );
+      const show = recentlyPlayedService.getShowByName(scheduleShow.name);
 
-      const showDetails = await scheduleService.getShowById(show.id);
-
-      if (showWithArchiveData && showWithArchiveData.archives.length > 0) {
+      if (show && show.archives.length > 0) {
         navigation.navigate('ShowDetails' as WmbrRouteName, {
-          show: showWithArchiveData,
-          showDescription: showDetails?.description || '',
+          show,
+          scheduleShow,
         });
       } else {
         // If no archives found, show info message
         Alert.alert(
-          show.name,
-          `No archived episodes found for "${show.name}". This show may not have been archived yet or may use a different name in the archive system.`,
+          scheduleShow.name,
+          `No archived episodes found for "${scheduleShow.name}". This show may not have been archived yet or may use a different name in the archive system.`,
           [{ text: 'OK' }],
         );
       }

--- a/src/app/Schedule/SchedulePage.tsx
+++ b/src/app/Schedule/SchedulePage.tsx
@@ -92,9 +92,12 @@ export default function SchedulePage({ currentShow }: SchedulePageProps) {
         show.name,
       );
 
+      const showDetails = await scheduleService.getShowById(show.id);
+
       if (showWithArchiveData && showWithArchiveData.archives.length > 0) {
         navigation.navigate('ShowDetails' as WmbrRouteName, {
           show: showWithArchiveData,
+          showDescription: showDetails?.description || '',
         });
       } else {
         // If no archives found, show info message

--- a/src/app/Schedule/ShowDetailsPage.tsx
+++ b/src/app/Schedule/ShowDetailsPage.tsx
@@ -62,7 +62,7 @@ const CIRCLE_DIAMETER = 16;
 // Route params for ShowDetailsPage
 export type ShowDetailsPageRouteParams = {
   show: Show;
-  scheduleShow?: ScheduleShow;
+  scheduleShow: ScheduleShow;
 };
 
 export default function ShowDetailsPage() {
@@ -314,7 +314,7 @@ export default function ShowDetailsPage() {
                   <Text style={styles.showHosts}>Hosted by {show.hosts}</Text>
                 )}
               </View>
-              {scheduleShow?.description && (
+              {scheduleShow.description && (
                 <Text style={styles.showDescription}>
                   {scheduleShow.description}
                 </Text>

--- a/src/app/Schedule/ShowDetailsPage.tsx
+++ b/src/app/Schedule/ShowDetailsPage.tsx
@@ -61,6 +61,7 @@ const CIRCLE_DIAMETER = 16;
 // Route params for ShowDetailsPage
 export type ShowDetailsPageRouteParams = {
   show: Show;
+  showDescription: string;
 };
 
 export default function ShowDetailsPage() {
@@ -69,7 +70,7 @@ export default function ShowDetailsPage() {
 
   const route =
     useRoute<RouteProp<Record<string, ShowDetailsPageRouteParams>, string>>();
-  const show: Show = route.params!.show;
+  const { show, showDescription } = route.params;
 
   const headerHeight = useHeaderHeight();
 
@@ -306,9 +307,14 @@ export default function ShowDetailsPage() {
             {/* Show Info */}
             <View style={styles.infoSection}>
               <Text style={styles.showTitle}>{show.name}</Text>
-              <Text style={styles.showSchedule}>{formatShowTime(show)}</Text>
-              {show.hosts && (
-                <Text style={styles.showHosts}>Hosted by {show.hosts}</Text>
+              <View>
+                <Text style={styles.showSchedule}>{formatShowTime(show)}</Text>
+                {show.hosts && (
+                  <Text style={styles.showHosts}>Hosted by {show.hosts}</Text>
+                )}
+              </View>
+              {showDescription && (
+                <Text style={styles.showDescription}>{showDescription}</Text>
               )}
               <Text style={styles.archiveCount}>
                 {archives.length} archived episode
@@ -473,27 +479,29 @@ const styles = StyleSheet.create({
   infoSection: {
     paddingHorizontal: 20,
     paddingBottom: 30,
+    flexDirection: 'column',
+    rowGap: 8,
   },
   showTitle: {
     color: COLORS.TEXT.PRIMARY,
     fontSize: 32,
     fontWeight: 'bold',
-    marginBottom: 8,
   },
   showSchedule: {
-    color: COLORS.TEXT.SECONDARY,
-    fontSize: 16,
-    marginBottom: 4,
+    color: COLORS.TEXT.TERTIARY,
+    fontSize: 14,
   },
   showHosts: {
-    color: COLORS.TEXT.SECONDARY,
+    color: COLORS.TEXT.TERTIARY,
+    fontSize: 14,
+  },
+  showDescription: {
+    color: COLORS.TEXT.PRIMARY,
     fontSize: 16,
-    marginBottom: 8,
   },
   archiveCount: {
-    color: COLORS.TEXT.SECONDARY,
+    color: COLORS.TEXT.TERTIARY,
     fontSize: 14,
-    fontWeight: '500',
   },
   archivesSection: {
     paddingHorizontal: 20,

--- a/src/app/Schedule/ShowDetailsPage.tsx
+++ b/src/app/Schedule/ShowDetailsPage.tsx
@@ -54,6 +54,7 @@ import {
   generateDarkGradientColors,
   generateGradientColors,
 } from '@utils/GradientColors';
+import { ScheduleShow } from '@customTypes/Schedule';
 
 const { width } = Dimensions.get('window');
 const CIRCLE_DIAMETER = 16;
@@ -61,7 +62,7 @@ const CIRCLE_DIAMETER = 16;
 // Route params for ShowDetailsPage
 export type ShowDetailsPageRouteParams = {
   show: Show;
-  showDescription: string;
+  scheduleShow: ScheduleShow;
 };
 
 export default function ShowDetailsPage() {
@@ -70,7 +71,7 @@ export default function ShowDetailsPage() {
 
   const route =
     useRoute<RouteProp<Record<string, ShowDetailsPageRouteParams>, string>>();
-  const { show, showDescription } = route.params;
+  const { show, scheduleShow } = route.params;
 
   const headerHeight = useHeaderHeight();
 
@@ -313,8 +314,10 @@ export default function ShowDetailsPage() {
                   <Text style={styles.showHosts}>Hosted by {show.hosts}</Text>
                 )}
               </View>
-              {showDescription && (
-                <Text style={styles.showDescription}>{showDescription}</Text>
+              {scheduleShow.description && (
+                <Text style={styles.showDescription}>
+                  {scheduleShow.description}
+                </Text>
               )}
               <Text style={styles.archiveCount}>
                 {archives.length} archived episode

--- a/src/app/Schedule/ShowDetailsPage.tsx
+++ b/src/app/Schedule/ShowDetailsPage.tsx
@@ -62,7 +62,7 @@ const CIRCLE_DIAMETER = 16;
 // Route params for ShowDetailsPage
 export type ShowDetailsPageRouteParams = {
   show: Show;
-  scheduleShow: ScheduleShow;
+  scheduleShow?: ScheduleShow;
 };
 
 export default function ShowDetailsPage() {
@@ -314,7 +314,7 @@ export default function ShowDetailsPage() {
                   <Text style={styles.showHosts}>Hosted by {show.hosts}</Text>
                 )}
               </View>
-              {scheduleShow.description && (
+              {scheduleShow?.description && (
                 <Text style={styles.showDescription}>
                   {scheduleShow.description}
                 </Text>

--- a/src/services/ScheduleService.ts
+++ b/src/services/ScheduleService.ts
@@ -192,6 +192,20 @@ export class ScheduleService {
     return weeksSince % 2 === 0;
   }
 
+  async getShowById(showId: string): Promise<ScheduleShow | null> {
+    try {
+      const scheduleData = await this.fetchSchedule();
+
+      const matchingShow =
+        scheduleData.shows.find(show => show.id === showId) || null;
+
+      return matchingShow;
+    } catch (error) {
+      debugError('Error getting show by ID:', error);
+      return null;
+    }
+  }
+
   // Helper method to find the previous show based on current time
   async findPreviousShow(
     currentShowName: string,

--- a/src/services/ScheduleService.ts
+++ b/src/services/ScheduleService.ts
@@ -192,20 +192,6 @@ export class ScheduleService {
     return weeksSince % 2 === 0;
   }
 
-  async getShowById(showId: string): Promise<ScheduleShow | null> {
-    try {
-      const scheduleData = await this.fetchSchedule();
-
-      const matchingShow =
-        scheduleData.shows.find(show => show.id === showId) || null;
-
-      return matchingShow;
-    } catch (error) {
-      debugError('Error getting show by ID:', error);
-      return null;
-    }
-  }
-
   // Helper method to find the previous show based on current time
   async findPreviousShow(
     currentShowName: string,

--- a/src/services/ScheduleService.ts
+++ b/src/services/ScheduleService.ts
@@ -192,6 +192,19 @@ export class ScheduleService {
     return weeksSince % 2 === 0;
   }
 
+  async getShowById(showId: string): Promise<ScheduleShow | undefined> {
+    try {
+      const scheduleData = await this.fetchSchedule();
+
+      const matchingShow = scheduleData.shows.find(show => show.id === showId);
+
+      return matchingShow;
+    } catch (error) {
+      debugError('Error getting show by ID:', error);
+      return;
+    }
+  }
+
   // Helper method to find the previous show based on current time
   async findPreviousShow(
     currentShowName: string,


### PR DESCRIPTION
Fixes #152, and sets us up to also show email address, URL, etc on show details page.

<img width="456" height="972" alt="Screenshot 2025-11-22 at 3 27 11 PM" src="https://github.com/user-attachments/assets/39960698-eade-4e3f-8116-89abd936581d" />
