### PR TITLE
fix: add right padding to show artwork (#143)

### DIFF
--- a/src/components/ShowImage.tsx
+++ b/src/components/ShowImage.tsx
@@ -81,7 +81,7 @@ const styles = StyleSheet.create({
   albumContent: {
     flex: 1,
     justifyContent: 'space-between',
-    paddingVertical: 16,
+    paddingVertical: 20,
     paddingHorizontal: 0,
   },
   albumLogoContainer: {


### PR DESCRIPTION
I also decreased the overall horizontal padding a little bit, seemed a little generous to me.

Closes #143

## Before

<img width="456" height="972" alt="Screenshot 2025-11-22 at 3 35 39 PM" src="https://github.com/user-attachments/assets/39541f66-3f16-4ee3-b449-9022b4d63d06" />

## After

<img width="456" height="972" alt="Screenshot 2025-11-22 at 3 37 44 PM" src="https://github.com/user-attachments/assets/78cd9809-8583-4506-80e3-e2f08985e201" />
