### PR TITLE
chore: add exempt encryption value to plist

### DIFF
--- a/ios/WmbrApp/Info.plist
+++ b/ios/WmbrApp/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>


### PR DESCRIPTION
This will prevent this message from appearing in App Store Connect:

<img width="695" height="476" alt="Screenshot 2025-11-30 at 11 47 52 AM" src="https://github.com/user-attachments/assets/433528ce-a5ab-4b62-be5b-93ad4c9c45ff" />
