### PR TITLE
fix: show artwork on lock screen with live stream (#142)

### DIFF
--- a/src/app/Home/index.tsx
+++ b/src/app/Home/index.tsx
@@ -115,6 +115,7 @@ export default function HomeScreen() {
           await TrackPlayer.updateMetadataForTrack(0, {
             title: DEFAULT_NAME,
             artist: currentShow || 'Live Radio',
+            artwork: require('../../../assets/cover.png'),
           });
         }
       } catch (error) {


### PR DESCRIPTION
Fixes #142