### PR TITLE
hotfix: fix alternating schedule check

### DIFF
--- a/__tests__/DateTime.test.ts
+++ b/__tests__/DateTime.test.ts
@@ -1,7 +1,11 @@
-import { parsePlaylistTimestamp } from '@utils/DateTime';
+import {
+  isAlternatingShowActive,
+  parsePlaylistTimestamp,
+} from '@utils/DateTime';
 
 // Mock the debugError function to avoid console noise in tests
 import { debugError } from '@utils/Debug';
+import { Show } from '@customTypes/RecentlyPlayed';
 
 const mockedDebugError = debugError as jest.MockedFunction<typeof debugError>;
 
@@ -152,5 +156,126 @@ describe('parsePlaylistTimestamp', () => {
       const result = parsePlaylistTimestamp('2024/01/15    14:30:45');
       expect(result).toEqual(new Date(2024, 0, 15, 14, 30, 45));
     });
+  });
+});
+
+describe('isAlternatingShowActive', () => {
+  const createShow = (alternates: number): Show => ({
+    id: 'show-id',
+    name: 'Test Show',
+    day: 1,
+    day_str: 'Monday',
+    time: 0,
+    time_str: '12:00 AM',
+    length: 60,
+    hosts: 'Test Host',
+    alternates,
+    archives: [],
+  });
+
+  const referenceDate = new Date(2026, 4, 25);
+
+  // These UTC values line up with midnight in New York during EDT,
+  // which keeps the week-boundary math stable in test environments.
+  const getEasternMidnightDate = (dateString: string) =>
+    new Date(`${dateString}T04:00:00Z`);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('returns true for a non-alternating show', () => {
+    const show = createShow(0);
+
+    expect(
+      isAlternatingShowActive(show, getEasternMidnightDate('2026-06-01'), null),
+    ).toBe(true);
+  });
+
+  test('returns false and logs when an alternating show has no reference date', () => {
+    const show = createShow(1);
+
+    expect(
+      isAlternatingShowActive(show, getEasternMidnightDate('2026-06-01'), null),
+    ).toBe(false);
+    expect(mockedDebugError).toHaveBeenCalledWith(
+      'Reference date for alternating shows is not set.',
+    );
+  });
+
+  test('treats alternates=1 as active on reference week and inactive the next week', () => {
+    const show = createShow(1);
+
+    expect(
+      isAlternatingShowActive(
+        show,
+        getEasternMidnightDate('2026-05-25'),
+        referenceDate,
+      ),
+    ).toBe(true);
+    expect(
+      isAlternatingShowActive(
+        show,
+        getEasternMidnightDate('2026-06-01'),
+        referenceDate,
+      ),
+    ).toBe(false);
+  });
+
+  test('treats alternates=2 as inactive on reference week and active the next week', () => {
+    const show = createShow(2);
+
+    expect(
+      isAlternatingShowActive(
+        show,
+        getEasternMidnightDate('2026-05-25'),
+        referenceDate,
+      ),
+    ).toBe(false);
+    expect(
+      isAlternatingShowActive(
+        show,
+        getEasternMidnightDate('2026-06-01'),
+        referenceDate,
+      ),
+    ).toBe(true);
+  });
+
+  test('treats alternates=5 as active on the first week of a four-week cycle', () => {
+    const show = createShow(5);
+
+    expect(
+      isAlternatingShowActive(
+        show,
+        getEasternMidnightDate('2026-05-25'),
+        referenceDate,
+      ),
+    ).toBe(true);
+    expect(
+      isAlternatingShowActive(
+        show,
+        getEasternMidnightDate('2026-06-01'),
+        referenceDate,
+      ),
+    ).toBe(false);
+  });
+
+  test('treats alternates=8 as active only on the fourth week of a four-week cycle', () => {
+    const show = createShow(8);
+
+    expect(
+      isAlternatingShowActive(
+        show,
+        getEasternMidnightDate('2026-06-15'),
+        referenceDate,
+      ),
+    ).toBe(true);
+    expect(
+      isAlternatingShowActive(
+        show,
+        getEasternMidnightDate('2026-06-08'),
+        referenceDate,
+      ),
+    ).toBe(false);
   });
 });

--- a/__tests__/DateTime.test.ts
+++ b/__tests__/DateTime.test.ts
@@ -173,12 +173,12 @@ describe('isAlternatingShowActive', () => {
     archives: [],
   });
 
-  const referenceDate = new Date(2026, 4, 25);
-
   // These UTC values line up with midnight in New York during EDT,
   // which keeps the week-boundary math stable in test environments.
   const getEasternMidnightDate = (dateString: string) =>
     new Date(`${dateString}T04:00:00Z`);
+
+  const referenceDate = getEasternMidnightDate('2026-05-25');
 
   beforeEach(() => {
     jest.clearAllMocks();

--- a/src/services/RecentlyPlayedService.ts
+++ b/src/services/RecentlyPlayedService.ts
@@ -647,13 +647,14 @@ export class RecentlyPlayedService {
     for (const show of shows) {
       const alternates = show.alternates;
 
-      const targetTimeEastern = new Date(
-        targetTime.toLocaleString('en-US', { timeZone: 'America/New_York' }),
+      const now = new Date();
+      const easternNow = new Date(
+        now.toLocaleString('en-US', { timeZone: 'America/New_York' }),
       );
 
       const shouldPlay = isAlternatingShowActive(
         show,
-        targetTimeEastern,
+        easternNow,
         firstSlotTime,
       );
 

--- a/src/services/RecentlyPlayedService.ts
+++ b/src/services/RecentlyPlayedService.ts
@@ -647,9 +647,13 @@ export class RecentlyPlayedService {
     for (const show of shows) {
       const alternates = show.alternates;
 
+      const targetTimeEastern = new Date(
+        targetTime.toLocaleString('en-US', { timeZone: 'America/New_York' }),
+      );
+
       const shouldPlay = isAlternatingShowActive(
         show,
-        targetTime,
+        targetTimeEastern,
         firstSlotTime,
       );
 

--- a/src/services/RecentlyPlayedService.ts
+++ b/src/services/RecentlyPlayedService.ts
@@ -8,7 +8,11 @@ import { ScheduleService } from './ScheduleService';
 import { ScheduleShow } from '@customTypes/Schedule';
 import { parseString } from 'react-native-xml2js';
 import { debugLog, debugError } from '@utils/Debug';
-import { getDateYMD, parsePlaylistTimestamp } from '@utils/DateTime';
+import {
+  getDateYMD,
+  isAlternatingShowActive,
+  parsePlaylistTimestamp,
+} from '@utils/DateTime';
 import { PlaylistSong, PlaylistResponse } from '@customTypes/Playlist';
 
 export class RecentlyPlayedService {
@@ -625,45 +629,11 @@ export class RecentlyPlayedService {
     const firstSlotTime = this.findFirstSlotTime(timeSlot, targetTime.getDay());
     if (!firstSlotTime) return shows[0];
 
-    // Calculate weeks since the first slot
-    const weeksSince = Math.floor(
-      (targetTime.getTime() - firstSlotTime.getTime()) /
-        (7 * 24 * 60 * 60 * 1000),
-    );
-    const cycleIndex = weeksSince % 4; // 0=week1, 1=week2, 2=week3, 3=week4
-
-    debugLog(
-      `Time slot ${timeSlot}: weeksSince=${weeksSince}, cycleIndex=${cycleIndex}`,
-    );
-
     // Find the show that matches this cycle
     for (const show of shows) {
       const alternates = show.alternates;
-      let shouldPlay = false;
 
-      switch (alternates) {
-        case 0: // Weekly show
-          shouldPlay = true;
-          break;
-        case 1: // Weeks 1 & 3 (first of every 2 weeks)
-          shouldPlay = weeksSince % 2 === 0;
-          break;
-        case 2: // Weeks 2 & 4 (second of every 2 weeks)
-          shouldPlay = weeksSince % 2 === 1;
-          break;
-        case 5: // Week 1 (first of every 4 weeks)
-          shouldPlay = cycleIndex === 0;
-          break;
-        case 6: // Week 2 (second of every 4 weeks)
-          shouldPlay = cycleIndex === 1;
-          break;
-        case 7: // Week 3 (third of every 4 weeks)
-          shouldPlay = cycleIndex === 2;
-          break;
-        case 8: // Week 4 (fourth of every 4 weeks)
-          shouldPlay = cycleIndex === 3;
-          break;
-      }
+      let shouldPlay = isAlternatingShowActive(show, targetTime);
 
       if (shouldPlay) {
         debugLog(`Selected show: ${show.name} (alternates=${alternates})`);

--- a/src/services/RecentlyPlayedService.ts
+++ b/src/services/RecentlyPlayedService.ts
@@ -266,6 +266,8 @@ export class RecentlyPlayedService {
 
           // Parse season start date if available
           if (result?.wmbr_archives?.$ && result.wmbr_archives.$.season_start) {
+            // This is formatted as:
+            // `season_start="Mon, 25 May 2026 14:00:00 GMT"`
             this.seasonStart = new Date(result.wmbr_archives.$.season_start);
             debugLog('Season start:', this.seasonStart);
           }
@@ -647,14 +649,9 @@ export class RecentlyPlayedService {
     for (const show of shows) {
       const alternates = show.alternates;
 
-      const now = new Date();
-      const easternNow = new Date(
-        now.toLocaleString('en-US', { timeZone: 'America/New_York' }),
-      );
-
       const shouldPlay = isAlternatingShowActive(
         show,
-        easternNow,
+        targetTime,
         firstSlotTime,
       );
 

--- a/src/services/RecentlyPlayedService.ts
+++ b/src/services/RecentlyPlayedService.ts
@@ -118,6 +118,20 @@ export class RecentlyPlayedService {
     }
   }
 
+  async getSeasonStart(): Promise<Date | null> {
+    if (this.seasonStart) {
+      return this.seasonStart;
+    }
+
+    try {
+      await this.fetchShowsCacheOnly();
+      return this.seasonStart;
+    } catch (error) {
+      debugError('Error fetching season start date:', error);
+      return null;
+    }
+  }
+
   getShowsCache(): Show[] {
     return this.showsCache;
   }

--- a/src/services/RecentlyPlayedService.ts
+++ b/src/services/RecentlyPlayedService.ts
@@ -633,7 +633,11 @@ export class RecentlyPlayedService {
     for (const show of shows) {
       const alternates = show.alternates;
 
-      let shouldPlay = isAlternatingShowActive(show, targetTime);
+      const shouldPlay = isAlternatingShowActive(
+        show,
+        targetTime,
+        this.seasonStart,
+      );
 
       if (shouldPlay) {
         debugLog(`Selected show: ${show.name} (alternates=${alternates})`);

--- a/src/services/RecentlyPlayedService.ts
+++ b/src/services/RecentlyPlayedService.ts
@@ -636,7 +636,7 @@ export class RecentlyPlayedService {
       const shouldPlay = isAlternatingShowActive(
         show,
         targetTime,
-        this.seasonStart,
+        firstSlotTime,
       );
 
       if (shouldPlay) {

--- a/src/services/ScheduleService.ts
+++ b/src/services/ScheduleService.ts
@@ -171,8 +171,8 @@ export class ScheduleService {
     }
 
     // For alternating shows, we need a reference date to calculate weeks.
-    // This should be checked each season and updated if the cycle changes.
-    const referenceDate = new Date('2026-05-17T00:00:00-04:00'); // Eastern Time
+    // This should be updated to the first Monday of every season.
+    const referenceDate = new Date('2026-05-24T00:00:00-04:00'); // Eastern Time
 
     const targetDateEastern = new Date(
       targetDate.toLocaleString('en-US', { timeZone: 'America/New_York' }),
@@ -187,10 +187,10 @@ export class ScheduleService {
     const weeksSince = Math.floor(daysDiff / 7);
 
     if (show.alternates < 3) {
-      return weeksSince % 2 === show.alternates - 1; // 1 means active on even weeks, 2 means active on odd weeks
+      return weeksSince % 2 === 2 - show.alternates; // 1 means active on odd weeks, 2 means active on even weeks
     }
 
-    return weeksSince % 4 === show.alternates - 5; // 5 means active on week 0, 6 means active on week 1, etc.
+    return weeksSince % 4 === show.alternates - 5; // 5 means active on week 1, 6 means active on week 2, etc.
   }
 
   async getShowById(showId: string): Promise<ScheduleShow | undefined> {

--- a/src/services/ScheduleService.ts
+++ b/src/services/ScheduleService.ts
@@ -1,7 +1,7 @@
 import { parseString } from 'react-native-xml2js';
 import { ScheduleShow, ScheduleResponse } from '@customTypes/Schedule';
 import { debugLog, debugError } from '@utils/Debug';
-import { dayNames } from '@utils/DateTime';
+import { dayNames, isAlternatingShowActive } from '@utils/DateTime';
 
 export class ScheduleService {
   private static instance: ScheduleService;
@@ -161,38 +161,6 @@ export class ScheduleService {
     return timeStr;
   }
 
-  // Helper method to determine if alternating show is active this week
-  private isAlternatingShowActive(
-    show: ScheduleShow,
-    targetDate: Date,
-  ): boolean {
-    if (show.alternates === 0) {
-      return true; // Non-alternating show is always active
-    }
-
-    // For alternating shows, we need a reference date to calculate weeks.
-    // This should be updated to the first Monday of every season.
-    const referenceDate = new Date('2026-05-24T00:00:00-04:00'); // Eastern Time
-
-    const targetDateEastern = new Date(
-      targetDate.toLocaleString('en-US', { timeZone: 'America/New_York' }),
-    );
-
-    // Calculate weeks since reference date.
-    const daysDiff = Math.floor(
-      (targetDateEastern.getTime() - referenceDate.getTime()) /
-        (1000 * 60 * 60 * 24),
-    );
-
-    const weeksSince = Math.floor(daysDiff / 7);
-
-    if (show.alternates < 3) {
-      return weeksSince % 2 === 2 - show.alternates; // 1 means active on odd weeks, 2 means active on even weeks
-    }
-
-    return weeksSince % 4 === show.alternates - 5; // 5 means active on week 1, 6 means active on week 2, etc.
-  }
-
   async getShowById(showId: string): Promise<ScheduleShow | undefined> {
     try {
       const scheduleData = await this.fetchSchedule();
@@ -240,7 +208,7 @@ export class ScheduleService {
 
       // Filter to only shows that are active this week (considering alternates)
       const todayShows = allTodayShows.filter(show =>
-        this.isAlternatingShowActive(show, easternNow),
+        isAlternatingShowActive(show, easternNow),
       );
 
       debugLog(`All shows for day ${scheduleDay}: ${allTodayShows.length}`);

--- a/src/services/ScheduleService.ts
+++ b/src/services/ScheduleService.ts
@@ -42,6 +42,8 @@ export class ScheduleService {
               result?.wmbr_archives?.$ &&
               result.wmbr_archives.$.season_start
             ) {
+              // This is formatted as:
+              // `season_start="Mon, 25 May 2026 14:00:00 GMT"`
               this.seasonStart = new Date(result.wmbr_archives.$.season_start);
             }
 
@@ -217,7 +219,7 @@ export class ScheduleService {
 
       // Filter to only shows that are active this week (considering alternates)
       const todayShows = allTodayShows.filter(show =>
-        isAlternatingShowActive(show, easternNow, this.seasonStart),
+        isAlternatingShowActive(show, now, this.seasonStart),
       );
 
       debugLog(`All shows for day ${scheduleDay}: ${allTodayShows.length}`);

--- a/src/services/ScheduleService.ts
+++ b/src/services/ScheduleService.ts
@@ -170,9 +170,12 @@ export class ScheduleService {
       return true; // Non-alternating show is always active
     }
 
+    const alternatingWeekIndex = show.alternates - 1; // Convert to 0-based index
+
     // For alternating shows, we need a reference date to calculate weeks
-    // Using a fixed reference date of September 1, 2024 (start of fall semester)
-    const referenceDate = new Date('2024-09-01T00:00:00-04:00'); // Eastern Time
+    // TODO: Needs to be checked each season and potentially updated
+    const referenceDate = new Date('2026-05-17T00:00:00-04:00'); // Eastern Time
+
     const targetDateEastern = new Date(
       targetDate.toLocaleString('en-US', { timeZone: 'America/New_York' }),
     );
@@ -185,11 +188,11 @@ export class ScheduleService {
     const weeksSince = Math.floor(daysDiff / 7);
 
     debugLog(
-      `Show "${show.name}" alternates: ${show.alternates}, weeks since ref: ${weeksSince}, active: ${weeksSince % 2 === 0}`,
+      `Show "${show.name}" alternates: ${show.alternates}, weeks since ref: ${weeksSince}, active: ${weeksSince % 2 === alternatingWeekIndex}`,
     );
 
     // Even weeks = first show in alternating pair, odd weeks = second show
-    return weeksSince % 2 === 0;
+    return weeksSince % 2 === alternatingWeekIndex;
   }
 
   async getShowById(showId: string): Promise<ScheduleShow | undefined> {

--- a/src/services/ScheduleService.ts
+++ b/src/services/ScheduleService.ts
@@ -170,29 +170,27 @@ export class ScheduleService {
       return true; // Non-alternating show is always active
     }
 
-    const alternatingWeekIndex = show.alternates - 1; // Convert to 0-based index
-
-    // For alternating shows, we need a reference date to calculate weeks
-    // TODO: Needs to be checked each season and potentially updated
+    // For alternating shows, we need a reference date to calculate weeks.
+    // This should be checked each season and updated if the cycle changes.
     const referenceDate = new Date('2026-05-17T00:00:00-04:00'); // Eastern Time
 
     const targetDateEastern = new Date(
       targetDate.toLocaleString('en-US', { timeZone: 'America/New_York' }),
     );
 
-    // Calculate weeks since reference date
+    // Calculate weeks since reference date.
     const daysDiff = Math.floor(
       (targetDateEastern.getTime() - referenceDate.getTime()) /
         (1000 * 60 * 60 * 24),
     );
+
     const weeksSince = Math.floor(daysDiff / 7);
 
-    debugLog(
-      `Show "${show.name}" alternates: ${show.alternates}, weeks since ref: ${weeksSince}, active: ${weeksSince % 2 === alternatingWeekIndex}`,
-    );
+    if (show.alternates < 3) {
+      return weeksSince % 2 === show.alternates - 1; // 1 means active on even weeks, 2 means active on odd weeks
+    }
 
-    // Even weeks = first show in alternating pair, odd weeks = second show
-    return weeksSince % 2 === alternatingWeekIndex;
+    return weeksSince % 4 === show.alternates - 5; // 5 means active on week 0, 6 means active on week 1, etc.
   }
 
   async getShowById(showId: string): Promise<ScheduleShow | undefined> {

--- a/src/services/ScheduleService.ts
+++ b/src/services/ScheduleService.ts
@@ -1,11 +1,11 @@
 import { parseString } from 'react-native-xml2js';
-import { RecentlyPlayedService } from '@services/RecentlyPlayedService';
 import { ScheduleShow, ScheduleResponse } from '@customTypes/Schedule';
 import { debugLog, debugError } from '@utils/Debug';
 import { dayNames, isAlternatingShowActive } from '@utils/DateTime';
 
 export class ScheduleService {
   private static instance: ScheduleService;
+  private seasonStart: Date | null = null;
   private readonly scheduleUrl = 'https://wmbr.org/cgi-bin/xmlsched';
   // Store the current "start of the broadcast day" (in minutes after midnight)
   // given by the root element of the schedule XML.
@@ -37,6 +37,14 @@ export class ScheduleService {
 
           try {
             debugLog('XML Parse Result:', JSON.stringify(result, null, 2));
+
+            if (
+              result?.wmbr_archives?.$ &&
+              result.wmbr_archives.$.season_start
+            ) {
+              this.seasonStart = new Date(result.wmbr_archives.$.season_start);
+            }
+
             this.dayStart =
               parseInt(result?.wmbr_schedule?.$?.daystart, 10) || 0;
             const shows = this.parseShows(result);
@@ -53,8 +61,6 @@ export class ScheduleService {
       throw error;
     }
   }
-
-  private recentlyPlayedService = RecentlyPlayedService.getInstance();
 
   private parseShows(xmlResult: any): ScheduleShow[] {
     debugLog('parseShows input:', xmlResult);
@@ -209,11 +215,9 @@ export class ScheduleService {
           (scheduleDay >= 1 && scheduleDay <= 5 && show.day === 7),
       );
 
-      const seasonStart = await this.recentlyPlayedService.getSeasonStart();
-
       // Filter to only shows that are active this week (considering alternates)
       const todayShows = allTodayShows.filter(show =>
-        isAlternatingShowActive(show, easternNow, seasonStart),
+        isAlternatingShowActive(show, easternNow, this.seasonStart),
       );
 
       debugLog(`All shows for day ${scheduleDay}: ${allTodayShows.length}`);

--- a/src/services/ScheduleService.ts
+++ b/src/services/ScheduleService.ts
@@ -206,9 +206,13 @@ export class ScheduleService {
           (scheduleDay >= 1 && scheduleDay <= 5 && show.day === 7),
       );
 
+      // For alternating shows, we need a reference date to calculate weeks.
+      // This should be updated to the first Monday of every season.
+      const referenceDate = new Date('2026-05-25T00:00:00-04:00'); // Eastern Time
+
       // Filter to only shows that are active this week (considering alternates)
       const todayShows = allTodayShows.filter(show =>
-        isAlternatingShowActive(show, easternNow),
+        isAlternatingShowActive(show, easternNow, referenceDate),
       );
 
       debugLog(`All shows for day ${scheduleDay}: ${allTodayShows.length}`);

--- a/src/services/ScheduleService.ts
+++ b/src/services/ScheduleService.ts
@@ -39,12 +39,12 @@ export class ScheduleService {
             debugLog('XML Parse Result:', JSON.stringify(result, null, 2));
 
             if (
-              result?.wmbr_archives?.$ &&
-              result.wmbr_archives.$.season_start
+              result?.wmbr_schedule?.$ &&
+              result.wmbr_schedule.$.season_start
             ) {
               // This is formatted as:
               // `season_start="Mon, 25 May 2026 14:00:00 GMT"`
-              this.seasonStart = new Date(result.wmbr_archives.$.season_start);
+              this.seasonStart = new Date(result.wmbr_schedule.$.season_start);
             }
 
             this.dayStart =

--- a/src/services/ScheduleService.ts
+++ b/src/services/ScheduleService.ts
@@ -1,4 +1,5 @@
 import { parseString } from 'react-native-xml2js';
+import { RecentlyPlayedService } from '@services/RecentlyPlayedService';
 import { ScheduleShow, ScheduleResponse } from '@customTypes/Schedule';
 import { debugLog, debugError } from '@utils/Debug';
 import { dayNames, isAlternatingShowActive } from '@utils/DateTime';
@@ -52,6 +53,8 @@ export class ScheduleService {
       throw error;
     }
   }
+
+  private recentlyPlayedService = RecentlyPlayedService.getInstance();
 
   private parseShows(xmlResult: any): ScheduleShow[] {
     debugLog('parseShows input:', xmlResult);
@@ -206,13 +209,11 @@ export class ScheduleService {
           (scheduleDay >= 1 && scheduleDay <= 5 && show.day === 7),
       );
 
-      // For alternating shows, we need a reference date to calculate weeks.
-      // This should be updated to the first Monday of every season.
-      const referenceDate = new Date('2026-05-25T00:00:00-04:00'); // Eastern Time
+      const seasonStart = await this.recentlyPlayedService.getSeasonStart();
 
       // Filter to only shows that are active this week (considering alternates)
       const todayShows = allTodayShows.filter(show =>
-        isAlternatingShowActive(show, easternNow, referenceDate),
+        isAlternatingShowActive(show, easternNow, seasonStart),
       );
 
       debugLog(`All shows for day ${scheduleDay}: ${allTodayShows.length}`);

--- a/src/utils/DateTime.ts
+++ b/src/utils/DateTime.ts
@@ -145,26 +145,26 @@ export const formatArchiveDate = (dateString: string) => {
 export const isAlternatingShowActive = (
   show: Show | ScheduleShow,
   targetDate: Date,
+  referenceDate: Date | null,
 ): boolean => {
   if (show.alternates === 0) {
     return true; // Non-alternating show is always active
   }
 
-  // For alternating shows, we need a reference date to calculate weeks.
-  // This should be updated to the first Monday of every season.
-  const referenceDate = new Date('2026-05-25T00:00:00-04:00'); // Eastern Time
+  if (!referenceDate) {
+    debugError('Reference date for alternating shows is not set.');
+    return false; // Default to inactive if we don't have a reference date
+  }
 
   const targetDateEastern = new Date(
     targetDate.toLocaleString('en-US', { timeZone: 'America/New_York' }),
   );
 
   // Calculate weeks since reference date.
-  const daysDiff = Math.floor(
+  const weeksSince = Math.floor(
     (targetDateEastern.getTime() - referenceDate.getTime()) /
-      (1000 * 60 * 60 * 24),
+      (7 * 24 * 60 * 60 * 1000),
   );
-
-  const weeksSince = Math.floor(daysDiff / 7);
 
   if (show.alternates < 3) {
     return weeksSince % 2 === show.alternates - 1; // 1 means active on odd weeks, 2 means active on even weeks

--- a/src/utils/DateTime.ts
+++ b/src/utils/DateTime.ts
@@ -167,7 +167,7 @@ export const isAlternatingShowActive = (
   );
 
   if (show.alternates < 3) {
-    return weeksSince % 2 === show.alternates - 1; // 1 means active on odd weeks, 2 means active on even weeks
+    return weeksSince % 2 === show.alternates - 1; // 1 is active on the reference week, 2 on the following week
   }
 
   return weeksSince % 4 === show.alternates - 5; // 5 means active on week 1, 6 means active on week 2, etc.

--- a/src/utils/DateTime.ts
+++ b/src/utils/DateTime.ts
@@ -2,6 +2,14 @@ import { Show } from '@customTypes/RecentlyPlayed';
 import { ScheduleShow } from '@customTypes/Schedule';
 import { debugError } from '@utils/Debug';
 
+const getEasternCalendarDate = (date: Date): Date => {
+  const easternDateString = date.toLocaleDateString('en-CA', {
+    timeZone: 'America/New_York',
+  });
+
+  return new Date(`${easternDateString}T00:00:00.000Z`);
+};
+
 export const dayNames = [
   'Sunday',
   'Monday',
@@ -156,9 +164,17 @@ export const isAlternatingShowActive = (
     return false; // Default to inactive if we don't have a reference date
   }
 
-  // Calculate weeks since reference date.
+  const normalizedTargetDate = getEasternCalendarDate(targetDate);
+  const normalizedReferenceDate = getEasternCalendarDate(referenceDate);
+
+  // Interpret both inputs by their Eastern calendar date.
+  // Callers pass real Date instants; the helper owns alternating-cycle
+  // normalization, and season_start is treated as the start of that Eastern
+  // calendar day rather than the literal XML timestamp.
+  // Compare Eastern calendar dates so the cycle changes on the Eastern week
+  // boundary instead of depending on local-device time.
   const weeksSince = Math.floor(
-    (targetDate.getTime() - referenceDate.getTime()) /
+    (normalizedTargetDate.getTime() - normalizedReferenceDate.getTime()) /
       (7 * 24 * 60 * 60 * 1000),
   );
 

--- a/src/utils/DateTime.ts
+++ b/src/utils/DateTime.ts
@@ -1,4 +1,5 @@
 import { Show } from '@customTypes/RecentlyPlayed';
+import { ScheduleShow } from '@customTypes/Schedule';
 import { debugError } from '@utils/Debug';
 
 export const dayNames = [
@@ -139,4 +140,35 @@ export const formatArchiveDate = (dateString: string) => {
     day: 'numeric',
     year: 'numeric',
   });
+};
+
+export const isAlternatingShowActive = (
+  show: Show | ScheduleShow,
+  targetDate: Date,
+): boolean => {
+  if (show.alternates === 0) {
+    return true; // Non-alternating show is always active
+  }
+
+  // For alternating shows, we need a reference date to calculate weeks.
+  // This should be updated to the first Monday of every season.
+  const referenceDate = new Date('2026-05-25T00:00:00-04:00'); // Eastern Time
+
+  const targetDateEastern = new Date(
+    targetDate.toLocaleString('en-US', { timeZone: 'America/New_York' }),
+  );
+
+  // Calculate weeks since reference date.
+  const daysDiff = Math.floor(
+    (targetDateEastern.getTime() - referenceDate.getTime()) /
+      (1000 * 60 * 60 * 24),
+  );
+
+  const weeksSince = Math.floor(daysDiff / 7);
+
+  if (show.alternates < 3) {
+    return weeksSince % 2 === show.alternates - 1; // 1 means active on odd weeks, 2 means active on even weeks
+  }
+
+  return weeksSince % 4 === show.alternates - 5; // 5 means active on week 1, 6 means active on week 2, etc.
 };

--- a/src/utils/DateTime.ts
+++ b/src/utils/DateTime.ts
@@ -156,13 +156,9 @@ export const isAlternatingShowActive = (
     return false; // Default to inactive if we don't have a reference date
   }
 
-  const targetDateEastern = new Date(
-    targetDate.toLocaleString('en-US', { timeZone: 'America/New_York' }),
-  );
-
   // Calculate weeks since reference date.
   const weeksSince = Math.floor(
-    (targetDateEastern.getTime() - referenceDate.getTime()) /
+    (targetDate.getTime() - referenceDate.getTime()) /
       (7 * 24 * 60 * 60 * 1000),
   );
 


### PR DESCRIPTION
The "is this alternating show active" check was just checking whether we were currently a multiple of 2 weeks from the reference date -- *not* whether the show's alternating value was the mod of the "weeks since."