### PR TITLE
Revert "fix: fix playback controls on lock screen for archives (#204)"

### DIFF
--- a/src/app/Home/index.tsx
+++ b/src/app/Home/index.tsx
@@ -86,6 +86,10 @@ export default function HomeScreen() {
         autoHandleInterruptions: true,
       });
 
+      await TrackPlayer.updateOptions({
+        capabilities: liveCapabilities,
+      });
+
       setIsPlayerInitialized(true);
     } catch (error) {
       debugError('Error setting up player:', error);
@@ -208,10 +212,6 @@ export default function HomeScreen() {
         }
 
         await TrackPlayer.play();
-
-        await TrackPlayer.updateOptions({
-          capabilities: liveCapabilities,
-        });
       }
     } catch (error) {
       debugError('Error toggling playback:', error);

--- a/src/services/ArchiveService.ts
+++ b/src/services/ArchiveService.ts
@@ -68,16 +68,16 @@ export class ArchiveService {
         userAgent: getUserAgent(),
       };
 
-      // Add and play archive
-      await TrackPlayer.add(archiveTrack);
-      await TrackPlayer.play();
-
       await TrackPlayer.updateOptions({
         capabilities: archiveCapabilities,
         compactCapabilities: archiveCapabilities,
         forwardJumpInterval: SKIP_INTERVAL,
         backwardJumpInterval: SKIP_INTERVAL,
       });
+
+      // Add and play archive
+      await TrackPlayer.add(archiveTrack);
+      await TrackPlayer.play();
 
       // Update state
       this.currentState = {


### PR DESCRIPTION
This didn't fix it, and in fact led to arguably more inconsistent behavior. Hotfixes should only be for new bugs and regressions, anyway, not trying to cram new bugfixes into a release branch.